### PR TITLE
permalinks to web (and other protocols, sure) fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Messages written in the SLOPI (pronounced "sloppy") communication style are:
 
 - Searchable: Messages can be found using Google or other search engines.
-- Linkable: Messages have a permalink.
+- Linkable: Messages have a permalink on the web.
 - Open: Messages are in the open.
 - Public: Messages are public.
 - Indexed: Messages are indexed by search engines.


### PR DESCRIPTION
Set expectations that permalinks over HTTP/HTTPS are
expected. XMPP permalinks would be fancy but should be
in addition to web links. See discussion in #8.